### PR TITLE
Add sleep() for offline memory consolidation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Node
+node_modules/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[codz]

--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ memory = Memory(subject_id="user_sarah")
 - `delete_block(label: str, subject_id: Optional[str] = None) -> None`
 - `add_messages_for_subject(subject_id: str, messages: list, skip_vector_storage: bool = True) -> str`
 - Unified: `add_messages(messages: list, skip_vector_storage: bool = True) -> str` (uses bound `subject_id`)
+- `sleep(subject_id: Optional[str] = None, include_archival: bool = False, archival_limit: int = 10) -> Optional[str]`
 
 Example:
 ```python
@@ -266,6 +267,39 @@ This searches Letta's archival memory (requires `skip_vector_storage=False` when
 messages = memory.search("user_id", query="system prompts", tags=["assistant"])  # assistant passages
 messages = memory.search("user_id", query="any", tags=[])  # no tag filter
 ```
+
+### Sleep (offline memory consolidation)
+
+Trigger a consolidation pass where the agent reviews, reorganizes, and refines its own memory blocks — resolving contradictions, merging redundancies, pruning stale information, and strengthening connections. No new external information is provided; the agent only works with what it already knows.
+
+**Python:**
+```python
+memory = Memory(subject_id="user_sarah")
+
+# Basic consolidation
+run = memory.sleep()
+if run:
+    memory.wait_for_run(run)
+
+# With archival memory review (promotes long-term memories back into active blocks)
+run = memory.sleep(include_archival=True, archival_limit=20)
+if run:
+    memory.wait_for_run(run)
+```
+
+**TypeScript:**
+```ts
+const memory = new Memory({ subjectId: 'user_sarah' });
+
+const run = await memory.sleep();
+if (run) await memory.waitForRun(run);
+
+// With archival review
+const run2 = await memory.sleep({ includeArchival: true, archivalLimit: 20 });
+if (run2) await memory.waitForRun(run2);
+```
+
+Returns `None`/`null` if the subject has no memory blocks to consolidate. Common patterns: run on a cron schedule, call after a burst of conversation, or use for periodic memory hygiene.
 
 ### Retrieving the memory agent
 
@@ -301,7 +335,7 @@ memory.delete_user("user_id")
 - [ ] Query messages by time
 - [x] TypeScript support
 - [ ] Learning from files
-- [ ] Add "sleep" (offline collective revisioning of all data)
+- [x] Add "sleep" (offline collective revisioning of all data)
 
 ### Implementation notes
 

--- a/src/python/ai_memory_sdk.py
+++ b/src/python/ai_memory_sdk.py
@@ -2,7 +2,7 @@ from typing import List, Dict, Any, Optional
 import time
 import os
 from letta_client import Letta
-from prompt_formatter import format_messages
+from prompt_formatter import format_messages, format_sleep_prompt
 from schemas import MessageCreate
 
 class Memory: 
@@ -293,6 +293,72 @@ class Memory:
         """Add messages using the instance's bound subject_id."""
         sid = self._get_effective_subject(None)
         return self.add_messages_for_subject(sid, messages, skip_vector_storage=skip_vector_storage)
+
+    def sleep(
+        self,
+        subject_id: Optional[str] = None,
+        include_archival: bool = False,
+        archival_limit: int = 10,
+    ) -> Optional[str]:
+        """Trigger offline memory consolidation for a subject.
+
+        Sends the agent a reflection prompt containing its current memory state,
+        asking it to review, reorganize, and refine its memory blocks. This is
+        analogous to memory consolidation during human sleep — the agent resolves
+        contradictions, merges redundancies, prunes stale information, and
+        strengthens connections between related facts.
+
+        Args:
+            subject_id: The subject to consolidate. Uses the instance default if
+                not provided.
+            include_archival: If True, also fetch recent passages from archival
+                memory and include them in the reflection prompt so the agent can
+                consider promoting long-term memories back into active blocks.
+            archival_limit: Maximum number of archival passages to include when
+                include_archival is True (default: 10).
+
+        Returns:
+            A run ID that can be passed to wait_for_run() to block until
+            consolidation is complete, or None if there are no memory blocks
+            to consolidate.
+
+        Example::
+
+            memory = Memory(subject_id="user_sarah")
+            run = memory.sleep()
+            if run:
+                memory.wait_for_run(run)
+        """
+        sid = self._get_effective_subject(subject_id)
+        agent_id = self._ensure_subject(sid)
+
+        blocks = self._list_context_blocks(agent_id)
+        if not blocks:
+            return None
+
+        archival_passages = None
+        if include_archival:
+            try:
+                response = self.letta_client.agents.passages.search(
+                    agent_id=agent_id,
+                    query="*",
+                    tags=[self._default_tag],
+                )
+                archival_passages = [
+                    result.content
+                    for result in (response.results or [])[:archival_limit]
+                ]
+            except Exception as e:
+                print(f"[ai-memory-sdk] Warning: archival search failed during sleep: {e}")
+                archival_passages = None
+
+        sleep_messages = format_sleep_prompt(blocks, archival_passages)
+
+        letta_run = self.letta_client.agents.messages.create_async(
+            agent_id=agent_id,
+            messages=sleep_messages,
+        )
+        return letta_run.id
 
     def initialize_user_memory(self,
         user_id: str,

--- a/src/python/prompt_formatter.py
+++ b/src/python/prompt_formatter.py
@@ -1,10 +1,12 @@
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 from schemas import Message, File
 
 
 messages_prompt = "The following message interactions have occured"
 messages_tag = "messages"
 message_total_char_limit = 5000 # how many character are included in a message chunk accross all messages
+
+sleep_tag = "sleep_consolidation"
 
 file_tag = "file"
 file_part_tag = "file_part"
@@ -24,6 +26,61 @@ def format_messages(messages: List[Message]) -> List[str]:
     ])
 
     return [{"role": "user", "content": f"<{messages_tag}>{messages_prompt}:\n{message_history}</{messages_tag}>"}]
+
+def format_sleep_prompt(
+    blocks: List[Any],
+    archival_passages: Optional[List[str]] = None,
+) -> List[Dict[str, str]]:
+    """
+    Format a sleep/consolidation prompt containing the current memory state.
+
+    The prompt asks the agent to review its own memory blocks and consolidate them:
+    resolve contradictions, merge redundancies, prune stale info, and reorganize.
+    """
+    # Format current block state
+    block_lines = []
+    for block in blocks:
+        label = getattr(block, "label", None)
+        description = getattr(block, "description", "")
+        value = getattr(block, "value", "")
+        if label is None:
+            continue
+        block_lines.append(
+            f'<block label="{label}" description="{description}">\n{value}\n</block>'
+        )
+    blocks_section = "\n\n".join(block_lines)
+
+    # Optional archival section
+    archival_section = ""
+    if archival_passages:
+        passages_text = "\n".join(f"- {p}" for p in archival_passages)
+        archival_section = (
+            f"\n\nThe following are recent passages from archival (long-term) memory. "
+            f"Consider whether any of this information should be promoted into your "
+            f"active memory blocks, or whether it reveals patterns worth capturing:\n"
+            f"{passages_text}"
+        )
+
+    prompt = (
+        f"<{sleep_tag}>\n"
+        f"You are entering a sleep/consolidation phase. No new external information "
+        f"is being provided. Instead, review your current memory state and improve it.\n\n"
+        f"Your tasks:\n"
+        f"1. Identify and resolve any contradictions between memory blocks\n"
+        f"2. Merge redundant information that appears across multiple blocks\n"
+        f"3. Remove or condense stale or outdated information\n"
+        f"4. Strengthen connections between related facts across blocks\n"
+        f"5. Reorganize information within blocks for clarity and coherence\n"
+        f"6. Note any gaps in your knowledge that future conversations should address\n\n"
+        f"Current memory blocks:\n{blocks_section}"
+        f"{archival_section}\n\n"
+        f"Update your memory blocks to reflect a consolidated, coherent understanding. "
+        f"Do not fabricate new information — only reorganize and refine what you already know.\n"
+        f"</{sleep_tag}>"
+    )
+
+    return [{"role": "user", "content": prompt}]
+
 
 def format_files(files: List[File]) -> List[Dict[str, str]]:
     """

--- a/src/python/tests/test_edge_cases.py
+++ b/src/python/tests/test_edge_cases.py
@@ -58,6 +58,13 @@ class _AgentsPassages:
     def create(self, agent_id: str, text: str, tags=None):
         return types.SimpleNamespace(id=f"passage-{agent_id}")
 
+    def search(self, agent_id: str, query: str, tags=None):
+        return types.SimpleNamespace(results=[
+            types.SimpleNamespace(content="archival passage 1"),
+            types.SimpleNamespace(content="archival passage 2"),
+            types.SimpleNamespace(content="archival passage 3"),
+        ])
+
 
 class _Agents:
     def __init__(self):
@@ -240,3 +247,53 @@ def test_long_block_value():
     result = memory.get_memory("data")
     assert result == long_value
     assert len(result) == 5000
+
+
+def test_sleep_basic():
+    """Test that sleep() returns a run ID when blocks exist"""
+    memory = Memory(subject_id="user_sleep")
+    memory.initialize_memory("human", "User info", value="Name: Alice", reset=True)
+    memory.initialize_memory("summary", "Summary", value="First chat", reset=True)
+
+    run_id = memory.sleep()
+    assert run_id is not None
+    assert run_id.startswith("run-")
+    memory.wait_for_run(run_id)
+
+
+def test_sleep_no_blocks_returns_none():
+    """Test that sleep() returns None when subject has no blocks"""
+    memory = Memory(subject_id="user_sleep_empty")
+    # Ensure the subject exists but has no blocks
+    memory._ensure_subject("user_sleep_empty")
+
+    run_id = memory.sleep()
+    assert run_id is None
+
+
+def test_sleep_with_archival():
+    """Test that sleep() with include_archival=True returns a run ID"""
+    memory = Memory(subject_id="user_sleep_archival")
+    memory.initialize_memory("notes", "Notes", value="Some notes", reset=True)
+
+    run_id = memory.sleep(include_archival=True, archival_limit=2)
+    assert run_id is not None
+    assert run_id.startswith("run-")
+
+
+def test_sleep_explicit_subject():
+    """Test that sleep() works with an explicit subject_id"""
+    memory = Memory()
+    memory.initialize_subject("project_sleep", reset=True)
+    memory.initialize_memory("spec", "Spec", value="v1", subject_id="project_sleep")
+
+    run_id = memory.sleep(subject_id="project_sleep")
+    assert run_id is not None
+    assert run_id.startswith("run-")
+
+
+def test_sleep_no_subject_raises():
+    """Test that sleep() raises when no subject is available"""
+    memory = Memory()
+    with pytest.raises(ValueError, match="No subject_id provided"):
+        memory.sleep()

--- a/src/typescript/src/memory.ts
+++ b/src/typescript/src/memory.ts
@@ -1,5 +1,5 @@
 import { LettaClient } from '@letta-ai/letta-client';
-import { formatMessages } from './prompt-formatter';
+import { formatMessages, formatSleepPrompt } from './prompt-formatter';
 import { MessageCreate } from './schemas';
 
 export interface MemoryConfig {
@@ -234,6 +234,55 @@ export class Memory {
   async addMessagesHere(messages: Record<string, any>[], skipVectorStorage: boolean = true): Promise<string> {
     const sid = this.getEffectiveSubject();
     return await this.addMessagesToSubject(sid, messages, skipVectorStorage);
+  }
+
+  /**
+   * Trigger offline memory consolidation for a subject.
+   *
+   * Sends the agent a reflection prompt containing its current memory state,
+   * asking it to review, reorganize, and refine its memory blocks. Analogous
+   * to memory consolidation during human sleep.
+   *
+   * @param options.subjectId - Subject to consolidate (uses instance default if omitted)
+   * @param options.includeArchival - Include recent archival passages in the reflection
+   * @param options.archivalLimit - Max archival passages to include (default: 10)
+   * @returns Run ID for use with waitForRun()
+   */
+  async sleep(options: {
+    subjectId?: string;
+    includeArchival?: boolean;
+    archivalLimit?: number;
+  } = {}): Promise<string | null> {
+    const { includeArchival = false, archivalLimit = 10 } = options;
+    const sid = this.getEffectiveSubject(options.subjectId);
+    const agentId = await this.ensureSubject(sid);
+
+    const blocks = await this.listContextBlocks(agentId);
+    if (blocks.length === 0) {
+      return null;
+    }
+
+    let archivalPassages: string[] | null = null;
+    if (includeArchival) {
+      try {
+        const response = await this.lettaClient.agents.passages.search(agentId, {
+          query: '*',
+          tags: ['ai-memory-sdk'],
+        });
+        archivalPassages = (response.results || [])
+          .slice(0, archivalLimit)
+          .map((r: any) => r.content);
+      } catch (e) {
+        console.warn('[ai-memory-sdk] Archival search failed during sleep:', e);
+        archivalPassages = null;
+      }
+    }
+
+    const sleepMessages = formatSleepPrompt(blocks, archivalPassages);
+    const lettaRun = await this.lettaClient.agents.messages.createAsync(agentId, {
+      messages: sleepMessages as any,
+    });
+    return lettaRun.id!;
   }
 
   async initializeUserMemory(

--- a/src/typescript/src/prompt-formatter.ts
+++ b/src/typescript/src/prompt-formatter.ts
@@ -9,6 +9,8 @@ const FILE_TAG = "file";
 const FILE_PART_TAG = "file_part";
 const FILE_CHAR_LIMIT = 20000;
 
+const SLEEP_TAG = "sleep_consolidation";
+
 export function formatMessages(messages: MessageCreate[]): Array<{ role: string; content: string }> {
   const messageHistory = messages
     .map(msg => `${msg.role}: ${msg.content}`)
@@ -18,6 +20,50 @@ export function formatMessages(messages: MessageCreate[]): Array<{ role: string;
     role: "user",
     content: `<${MESSAGES_TAG}>${MESSAGES_PROMPT}:\n${messageHistory}</${MESSAGES_TAG}>`
   }];
+}
+
+export function formatSleepPrompt(
+  blocks: any[],
+  archivalPassages?: string[] | null,
+): Array<{ role: string; content: string }> {
+  const blockLines = blocks
+    .filter((b: any) => b.label)
+    .map((b: any) => {
+      const label = b.label;
+      const description = b.description || '';
+      const value = b.value || '';
+      return `<block label="${label}" description="${description}">\n${value}\n</block>`;
+    });
+  const blocksSection = blockLines.join('\n\n');
+
+  let archivalSection = '';
+  if (archivalPassages && archivalPassages.length > 0) {
+    const passagesText = archivalPassages.map(p => `- ${p}`).join('\n');
+    archivalSection =
+      `\n\nThe following are recent passages from archival (long-term) memory. ` +
+      `Consider whether any of this information should be promoted into your ` +
+      `active memory blocks, or whether it reveals patterns worth capturing:\n` +
+      passagesText;
+  }
+
+  const prompt =
+    `<${SLEEP_TAG}>\n` +
+    `You are entering a sleep/consolidation phase. No new external information ` +
+    `is being provided. Instead, review your current memory state and improve it.\n\n` +
+    `Your tasks:\n` +
+    `1. Identify and resolve any contradictions between memory blocks\n` +
+    `2. Merge redundant information that appears across multiple blocks\n` +
+    `3. Remove or condense stale or outdated information\n` +
+    `4. Strengthen connections between related facts across blocks\n` +
+    `5. Reorganize information within blocks for clarity and coherence\n` +
+    `6. Note any gaps in your knowledge that future conversations should address\n\n` +
+    `Current memory blocks:\n${blocksSection}` +
+    `${archivalSection}\n\n` +
+    `Update your memory blocks to reflect a consolidated, coherent understanding. ` +
+    `Do not fabricate new information — only reorganize and refine what you already know.\n` +
+    `</${SLEEP_TAG}>`;
+
+  return [{ role: 'user', content: prompt }];
 }
 
 export function formatFiles(files: File[]): Array<{ role: string; content: string }> {

--- a/src/typescript/tests/prompt-formatter.test.ts
+++ b/src/typescript/tests/prompt-formatter.test.ts
@@ -1,4 +1,4 @@
-import { formatMessages, formatFiles } from '../src/prompt-formatter';
+import { formatMessages, formatFiles, formatSleepPrompt } from '../src/prompt-formatter';
 import { MessageCreate, File } from '../src/schemas';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -283,6 +283,110 @@ function testFormatFilesMultiple() {
   }
 }
 
+function testFormatSleepPromptBasic() {
+  console.log('Testing formatSleepPrompt with blocks...');
+
+  const blocks = [
+    { label: 'human', description: 'User info', value: 'Name: Alice' },
+    { label: 'summary', description: 'Conversation summary', value: 'Discussed cats' },
+  ];
+
+  const result = formatSleepPrompt(blocks);
+
+  if (result.length !== 1) {
+    throw new Error(`Expected 1 message, got ${result.length}`);
+  }
+  if (result[0].role !== 'user') {
+    throw new Error(`Expected role 'user', got '${result[0].role}'`);
+  }
+
+  const content = result[0].content;
+  const expected = [
+    '<sleep_consolidation>',
+    'sleep/consolidation phase',
+    '<block label="human" description="User info">',
+    'Name: Alice',
+    '<block label="summary" description="Conversation summary">',
+    'Discussed cats',
+    '</sleep_consolidation>',
+  ];
+  for (const part of expected) {
+    if (!content.includes(part)) {
+      throw new Error(`Expected content to contain '${part}'`);
+    }
+  }
+
+  console.log('✓ formatSleepPrompt basic works correctly');
+}
+
+function testFormatSleepPromptWithArchival() {
+  console.log('Testing formatSleepPrompt with archival passages...');
+
+  const blocks = [
+    { label: 'human', description: 'User info', value: 'Name: Bob' },
+  ];
+  const archival = ['User mentioned liking jazz', 'User works at Acme Corp'];
+
+  const result = formatSleepPrompt(blocks, archival);
+  const content = result[0].content;
+
+  if (!content.includes('archival (long-term) memory')) {
+    throw new Error('Expected archival section header');
+  }
+  if (!content.includes('- User mentioned liking jazz')) {
+    throw new Error('Expected first archival passage');
+  }
+  if (!content.includes('- User works at Acme Corp')) {
+    throw new Error('Expected second archival passage');
+  }
+
+  console.log('✓ formatSleepPrompt with archival works correctly');
+}
+
+function testFormatSleepPromptNoArchival() {
+  console.log('Testing formatSleepPrompt without archival...');
+
+  const blocks = [
+    { label: 'notes', description: 'Notes', value: 'Some notes' },
+  ];
+
+  const result = formatSleepPrompt(blocks, null);
+  const content = result[0].content;
+
+  if (content.includes('archival (long-term) memory')) {
+    throw new Error('Should not contain archival section when null');
+  }
+
+  const result2 = formatSleepPrompt(blocks, []);
+  if (result2[0].content.includes('archival (long-term) memory')) {
+    throw new Error('Should not contain archival section when empty array');
+  }
+
+  console.log('✓ formatSleepPrompt without archival works correctly');
+}
+
+function testFormatSleepPromptSkipsLabelless() {
+  console.log('Testing formatSleepPrompt skips blocks without labels...');
+
+  const blocks = [
+    { label: 'human', description: 'Info', value: 'Alice' },
+    { description: 'No label', value: 'Should be skipped' },
+    { label: '', description: 'Empty label', value: 'Also skipped' },
+  ];
+
+  const result = formatSleepPrompt(blocks);
+  const content = result[0].content;
+
+  if (!content.includes('Alice')) {
+    throw new Error('Expected labeled block content');
+  }
+  if (content.includes('Should be skipped')) {
+    throw new Error('Block without label should be skipped');
+  }
+
+  console.log('✓ formatSleepPrompt skips labelless blocks');
+}
+
 function runAllTests() {
   console.log('Running Prompt Formatter tests...\n');
 
@@ -306,6 +410,18 @@ function runAllTests() {
     console.log();
     
     testFormatFilesMultiple();
+    console.log();
+
+    testFormatSleepPromptBasic();
+    console.log();
+
+    testFormatSleepPromptWithArchival();
+    console.log();
+
+    testFormatSleepPromptNoArchival();
+    console.log();
+
+    testFormatSleepPromptSkipsLabelless();
     console.log();
 
     console.log('✅ All Prompt Formatter tests passed!');

--- a/src/typescript/tests/subject.test.ts
+++ b/src/typescript/tests/subject.test.ts
@@ -57,6 +57,13 @@ function createFakeLetta() {
       },
       passages: {
         create: async (_agentId: string, _payload: any) => ({}),
+        search: async (_agentId: string, _payload: any) => ({
+          results: [
+            { content: 'archival passage 1' },
+            { content: 'archival passage 2' },
+            { content: 'archival passage 3' },
+          ],
+        }),
       },
     },
     blocks: {
@@ -127,13 +134,107 @@ async function testExplicitContext() {
   console.log('✓ Explicit subject passed');
 }
 
+async function testSleepBasic() {
+  console.log('Testing sleep() with blocks...');
+
+  const memory = new Memory({ subjectId: 'user_sleep' });
+  (memory as any).lettaClient = createFakeLetta();
+
+  await memory.initializeMemory('human', 'User info', 'Name: Alice', 10000, true);
+  await memory.initializeMemory('summary', 'Summary', 'First chat', 10000, true);
+
+  const runId = await memory.sleep();
+  if (!runId || !runId.startsWith('run-')) {
+    throw new Error(`Expected run ID, got ${runId}`);
+  }
+  await memory.waitForRun(runId);
+
+  console.log('✓ sleep() with blocks passed');
+}
+
+async function testSleepNoBlocks() {
+  console.log('Testing sleep() with no blocks...');
+
+  const memory = new Memory({ subjectId: 'user_sleep_empty' });
+  (memory as any).lettaClient = createFakeLetta();
+
+  // Ensure subject exists but has no blocks
+  await memory.initializeSubject('user_sleep_empty', true);
+
+  const runId = await memory.sleep();
+  if (runId !== null) {
+    throw new Error(`Expected null for empty blocks, got ${runId}`);
+  }
+
+  console.log('✓ sleep() with no blocks returns null');
+}
+
+async function testSleepWithArchival() {
+  console.log('Testing sleep() with archival...');
+
+  const memory = new Memory({ subjectId: 'user_sleep_arch' });
+  (memory as any).lettaClient = createFakeLetta();
+
+  await memory.initializeMemory('notes', 'Notes', 'Some notes', 10000, true);
+
+  const runId = await memory.sleep({ includeArchival: true, archivalLimit: 2 });
+  if (!runId || !runId.startsWith('run-')) {
+    throw new Error(`Expected run ID, got ${runId}`);
+  }
+
+  console.log('✓ sleep() with archival passed');
+}
+
+async function testSleepExplicitSubject() {
+  console.log('Testing sleep() with explicit subject...');
+
+  const memory = new Memory();
+  (memory as any).lettaClient = createFakeLetta();
+
+  await memory.initializeSubject('project_sleep', true);
+  await memory.initializeMemory('spec', 'Spec', 'v1', 10000, false, 'project_sleep');
+
+  const runId = await memory.sleep({ subjectId: 'project_sleep' });
+  if (!runId || !runId.startsWith('run-')) {
+    throw new Error(`Expected run ID, got ${runId}`);
+  }
+
+  console.log('✓ sleep() with explicit subject passed');
+}
+
+async function testSleepNoSubjectThrows() {
+  console.log('Testing sleep() without subject throws...');
+
+  const memory = new Memory();
+  (memory as any).lettaClient = createFakeLetta();
+
+  let threw = false;
+  try {
+    await memory.sleep();
+  } catch (e) {
+    if (e instanceof Error && e.message.includes('No subjectId provided')) {
+      threw = true;
+    } else {
+      throw e;
+    }
+  }
+  if (!threw) throw new Error('Expected error for missing subjectId');
+
+  console.log('✓ sleep() without subject throws');
+}
+
 async function runAllTests() {
   try {
     await testInstanceScopedContext();
     await testExplicitContext();
-    console.log('✅ Context tests passed');
+    await testSleepBasic();
+    await testSleepNoBlocks();
+    await testSleepWithArchival();
+    await testSleepExplicitSubject();
+    await testSleepNoSubjectThrows();
+    console.log('✅ All context + sleep tests passed');
   } catch (err) {
-    console.error('❌ Context test failed:', err instanceof Error ? err.message : String(err));
+    console.error('❌ Test failed:', err instanceof Error ? err.message : String(err));
     process.exit(1);
   }
 }


### PR DESCRIPTION
## Summary

- Adds `sleep()` method to both Python and TypeScript `Memory` classes for offline memory consolidation — the agent reviews, reorganizes, and refines its own memory blocks without external input
- Supports optional archival memory review (`include_archival=True`) to promote long-term passages back into active blocks
- Returns `None`/`null` when no blocks exist to avoid wasted LLM calls

## Changes

**Core implementation (Python + TypeScript):**
- `Memory.sleep()` — gathers current blocks, builds a structured reflection prompt, sends it via `create_async`
- `format_sleep_prompt()` / `formatSleepPrompt()` — formats blocks and optional archival passages into a `<sleep_consolidation>` tagged prompt
- Uses existing `_ensure_subject` for agent resolution (no redundant API calls)
- Archival search failures are logged as warnings rather than silently swallowed

**Tests:**
- Python: 5 new tests in `test_edge_cases.py` (basic, no-blocks, archival, explicit subject, no-subject error)
- TypeScript: 5 new tests in `subject.test.ts` (same coverage matrix)
- TypeScript: 4 new tests in `prompt-formatter.test.ts` (basic, archival, no-archival, labelless blocks)

**Docs:**
- README: new "Sleep (offline memory consolidation)" section with Python + TS examples
- README: `sleep()` added to Subject methods API reference
- README: roadmap item checked off

## Test plan

- [x] All 16 Python offline tests pass (`pytest tests/test_edge_cases.py tests/test_subject.py`)
- [x] All 7 TS subject tests pass (`tsx tests/subject.test.ts`)
- [x] All 11 TS prompt-formatter tests pass (`tsx tests/prompt-formatter.test.ts`)
- [x] Zero regressions on pre-existing tests
- [ ] Manual integration test with a live Letta API key (calling `sleep()` on a subject with populated blocks)


Made with [Cursor](https://cursor.com)